### PR TITLE
Prefer HTML_URL and support fail on no task(s)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   on_open_action:
     description: 'The action to perform when a PR is opened (CLOSE|MOVE <Section Name>)'
     required: false
+  fail_on_no_task:
+    description: 'Make the action fail if there are no found tasks'
+    required: false
   on_merge_action:
     description: 'The action to perform when a PR is merged (CLOSE|MOVE <Section Name>).  Defaults to CLOSE'
     required: false


### PR DESCRIPTION
Not quite sure how to properly test this as I can't link to an Asana task (since I dont have permissions)

The goal of the PR is to prefer `pull_request.html_url` (https://github.com/actions/toolkit/blob/fc005283374f1cea5e03ea1caf959cd9ff12fdc2/packages/github/src/interfaces.ts#L27) 
Since the current comment in Asana points to a GitHub API link. As mentioned here: https://github.com/ExodusMovement/asana-actions/issues/23

Also added support to make the action fail if there are no Asana tasks linked/found. Our process in our repo is to always link and this would be great

Thanks so much for an awesome repo! :) 

PS: If there are proper steps to test using a real Asana workspace please let me know, I'll be more than happy to test it!