### PR TITLE
Refactor: move to section per project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ This GitHub Action will link Asana tasks to GitHub Pull Requests. When a PR is m
 When you open a PR put the last 4 or more digits from the task ID in the url of the task from Asana into the PR title in the format `!1234`, for example `fix: handle uncaught exception !7194`. Your PR description will be updated by this action to link to the Asana task. When you merge your PR, the Asana task will be marked as completed.
 
 By default no action additional action will be taken when the PR is opened and the task will be closed when the PR is merged.  Use inputs
-`on_open_action` and `on_merge_action` to customize this.  The keyword `CLOSE` is used to close the task, the keyword `MOVE_TO_SECTION <SectionId>` where `<SectionId>` is the gid of the section to target, will move the Asana task to a new section.
+`on_open_action` and `on_merge_action` to customize this.  The keyword `CLOSE` is used to close the task, the keyword `MOVE_TO_SECTION <ProjectId>/<SectionId>` where
+`<ProjectId>` is the gid of the project the section targetted is in.
+`<SectionId>` is the gid of the section to target, will move the Asana task to a new section.
+
+Multiple pairs can be added. E.g. `<ProjectId>/<SectionId> <ProjectId>/<SectionId>`
 
 You can also merge multiple tasks by separating them with comma using the same format `!1234,3456,7890` e.g `doc: document third party integrations !7212,7213,7214`
 
@@ -55,5 +59,4 @@ Testing currently requires a live Asana environment to test with, you will need 
 - Create a new release on https://github.com/ExodusMovement/asana-actions/releases with the `Tag version` field set to the same semver that you just pushed
 - Finally, open a PR for your branch. It should automatically run your action on that PR
 
-  NB: If you have opened the PR prior to the actions above, edit and save the PR title and it should run the action
-
+NB: If you have opened the PR prior to the actions above, edit and save the PR title and it should run the action

--- a/index.js
+++ b/index.js
@@ -56,11 +56,10 @@ const run = async () => {
     const isMoveAction = (onAction) => {
       return onAction.startsWith(ACTION_MOVE_TO_SECTION_PREFIX)
     }
-
-    const getSectionFromAction = (onAction) => {
+    const getProjectAndSectionFromAction = (onAction) => {
       return onAction
         .substring(ACTION_MOVE_TO_SECTION_PREFIX.length, onAction.length)
-        .trim()
+        .trim().split(' ')
     }
 
     const doAction = async (tasks, onAction) => {
@@ -69,10 +68,10 @@ const run = async () => {
         core.info('Marked linked Asana task(s) as completed')
       }
       if (isMoveAction(onAction)) {
-        const sectionId = getSectionFromAction(onAction)
-        core.info('Moving Asana task(s) to section ' + sectionId)
-        await utils.moveAsanaTasksToSection(asana_token, tasks, sectionId)
-        core.info('Moved linked Asana task(s) to section ' + sectionId)
+        const projectSectionPairs = getProjectAndSectionFromAction(onAction)
+        core.info('Moving Asana task(s) to section ' + projectSectionPairs)
+        await utils.moveAsanaTasksToSection(asana_token, tasks, projectSectionPairs)
+        core.info('Moved linked Asana task(s) to section ' + projectSectionPairs)
       }
     }
 

--- a/utils.js
+++ b/utils.js
@@ -64,7 +64,7 @@ module.exports.getComments = async function (token, taskId, offset) {
 module.exports.hasPRComments = async function (token, taskId) {
   let offset
   while (true) {
-    const rowsData = await module.exports.getComments(token, taskId, offset)
+    const rowsData = await getComments(token, taskId, offset)
     const rows = rowsData.data
     if (!rows || !rows.length) {
       break
@@ -113,17 +113,27 @@ module.exports.completeAsanaTasks = async function (token, tasks) {
   }
 }
 
-module.exports.moveAsanaTasksToSection = async function (token, tasks, sectionId) {
+module.exports.moveAsanaTasksToSection = async function (token, tasks, projectSectionPairs) {
   if (!tasks || !tasks.length) return
   try {
+    const validSectionIds = [];
     await Promise.all([...tasks].map(task => (
-      fetch(token)(`sections/${sectionId}/addTask`).post({
-        'data': {
-          'task': task.gid
+      projectSectionPairs.map(string => {
+        const [projectId, sectionId] = string.split("/")
+        // check if task is in project
+        const taskInProject = task.projects.some(project => project.gid === projectId);
+        if (taskInProject) {
+          // if task is in project, then move to section
+          validSectionIds.push(sectionId)
+          fetch(token)(`sections/${sectionId}/addTask`).post({
+            'data': {
+              'task': task.gid
+            }
+          })
         }
       })
     )))
-    core.info(`posted task(s) (${tasks.map(stripTaskIds)}) to sections/${sectionId}/addTask`)
+    core.info(`posted task(s) (${tasks.map(stripTaskIds)}) to sections/${validSectionIds}/addTask`)
   } catch (exc) {
     core.error(`Error while posting task(s) (${tasks.map(stripTaskIds)}) to sections/${sectionId}/addTask`)
   }
@@ -131,7 +141,7 @@ module.exports.moveAsanaTasksToSection = async function (token, tasks, sectionId
 
 module.exports.searchByDate = async function (token, gid, before, after) {
   const url = 'workspaces/' + gid + '/tasks/search' +
-    '?opt_fields=gid,name' +
+    '?opt_fields=gid,name,projects' +
     '&modified_at.before=' + before.toISOString() +
     '&modified_at.after=' + after.toISOString() +
     '&limit=100' +
@@ -154,7 +164,7 @@ module.exports.getMatchingAsanaTasks = async function (token, gid, ids) {
   }
   while (lookedAt < 10000 && callsMade < 100) {
     d2.setHours(d2.getHours() - hoursInc)
-    const rows = await module.exports.searchByDate(token, gid, d1, d2)
+    const rows = await searchByDate(token, gid, d1, d2)
     callsMade++
     lookedAt += rows.length
     for (let i = 0; i < rows.length; i++) {
@@ -177,12 +187,12 @@ module.exports.addGithubPrToAsanaTask = async function (token, tasks, title, url
   if (!tasks || !tasks.length) return
   const tasksToComment = []
   for (const task of tasks) {
-    const checkCommentInTask = await module.exports.hasPRComments(token, task.gid)
+    const checkCommentInTask = await hasPRComments(token, task.gid)
     if (!checkCommentInTask) tasksToComment.push(task)
   }
   if (!tasksToComment.length) return
   const comment = '<strong>' + PULL_REQUEST_PREFIX + '</strong> ' + xmlescape(title) + '\n<a href="' + url + '"/>'
-  await module.exports.addAsanaComment(token, tasks, comment)
+  await addAsanaComment(token, tasks, comment)
 }
 
 module.exports.getAsanaShortIds = function getAsanaShortIds(str) {


### PR DESCRIPTION
## Summary
This PR allows a task to be moved to specified sections per project. This means that the admin will add to the environment variables multiple ProjectIds and SectionIds. An example is found below:

`<ProjectId>/<SectionId> <ProjectId>/<SectionId> <ProjectId>/<SectionId> <ProjectId>/<SectionId>`

## Test Plan
I am yet to test it

## Further Comments
I will need help testing it
